### PR TITLE
Use "correct" base URL in GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           tool: zola@0.19.1
 
-      - run: zola build
+      - run: zola build --base-url '/'
 
       - name: Check links
         id: lychee

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,7 +20,7 @@ jobs:
           tool: zola@0.19.1
 
       - name: Build
-        run: zola build --drafts
+        run: zola build --drafts --base-url '/'
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -59,3 +59,4 @@ jobs:
           SMOKESHOW_AUTH_KEY: ${{ secrets.SMOKESHOW_AUTH_KEY }}
           SMOKESHOW_GITHUB_STATUS_DESCRIPTION: Preview
           SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This PR makes `check-links` and `preview` GHA workflows use the `/` base URL. That makes absolute URLs not include the domain name, which makes little sense for Smokeshow and breaks on not-yet-published pages in Lychee